### PR TITLE
Automatic Container creation for arm and x86

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [net]
 git-fetch-with-cli = true
+
+[registries.crates-io]
+protocol = "sparse"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+env: 
+  TRAPS_REL: ${{ github.event.release.tag_name }}
+
 jobs:
   docker:
 
@@ -26,4 +29,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_engine:${{ github.event.release.tag_name }}
+          tags: skhuvis/camera_traps_engine:$TRAPS_REL

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,6 +38,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/pyevents
+      - name: Build and push pyevents:3.8
+        uses: docker/build-push-action@v5
+        with:
+          context: https://github.com/tapis-project/event-engine.git#:pyevents
+          file: https://raw.githubusercontent.com/tapis-project/event-engine/main/pyevents/Dockerfile-3.8
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/pyevents:3.8
       - name: Build and push camera_traps_py
         uses: docker/build-push-action@v5
         with:
@@ -45,14 +53,23 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/camera_traps_py:${{ env.TRAPS_REL }}
+      - name: Build and push camera_traps_py_3.8
+        uses: docker/build-push-action@v5
+        with:
+          context: src/python
+          file: src/python/Dockerfile-3.8
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/camera_traps_py_3.8:${{ env.TRAPS_REL }}
       - name: Build and push image_scoring_plugin
         uses: docker/build-push-action@v5
         with:
           context: external_plugins/image_scoring_plugin
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/image_scoring_plugin_py:${{ env.TRAPS_REL }}
+          tags: skhuvis/image_scoring_plugin_py_3.8:${{ env.TRAPS_REL }}
           build-args: REL=${{ env.TRAPS_REL }}
+          file: external_plugins/image_scoring_plugin/Dockerfile-3.8
       - name: Build and push image_generating_plugin
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  docker:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push engine
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/camera_traps_engine:${{ github.event.release.tag_name }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push pyevents
         uses: docker/build-push-action@v5
         with:
-          context: https://github.com/tapis-project/event-engine.git:pyevents
+          context: https://github.com/tapis-project/event-engine.git#:pyevents
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/pyevents:${{ env.TRAPS_REL }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,3 +30,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/camera_traps_engine:$TRAPS_REL
+          build-args: TRAPS_REL=$TRAPS_REL

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,11 +23,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push engine
+#      - name: Build and push engine
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
+#          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+      - name: Build and push pyevents
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: https://github.com/tapis-project/event-engine.git:pyevents
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
-          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+          tags: skhuvis/pyevents:${{ env.TRAPS_REL }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,10 +31,17 @@ jobs:
 #          push: true
 #          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
 #          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
-      - name: Build and push pyevents
+#      - name: Build and push pyevents
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: https://github.com/tapis-project/event-engine.git#:pyevents
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          tags: skhuvis/pyevents
+      - name: Build and push camera_traps_py
         uses: docker/build-push-action@v5
         with:
-          context: https://github.com/tapis-project/event-engine.git#:pyevents
+          context: src/python
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/pyevents
+          tags: skhuvis/camera_traps_py

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,7 +52,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/image_scoring_plugin_py:${{ env.TRAPS_REL }}
-          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+          build-args: REL=${{ env.TRAPS_REL }}
       - name: Build and push image_generating_plugin
         uses: docker/build-push-action@v5
         with:
@@ -60,7 +60,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/image_generating_plugin_py:${{ env.TRAPS_REL }}
-          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+          build-args: REL=${{ env.TRAPS_REL }}
       - name: Build and push power_measuring_plugin
         uses: docker/build-push-action@v5
         with:
@@ -68,4 +68,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: skhuvis/power_measuring_plugin_py:${{ env.TRAPS_REL }}
-          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+          build-args: REL=${{ env.TRAPS_REL }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,4 +37,4 @@ jobs:
           context: https://github.com/tapis-project/event-engine.git#:pyevents
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/pyevents:${{ env.TRAPS_REL }}
+          tags: skhuvis/pyevents

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
+          tags: tapis/camera_traps_engine:${{ env.TRAPS_REL }}
           build-args: TRAPS_REL=${{ env.TRAPS_REL }}
       - name: Build and push pyevents
         uses: docker/build-push-action@v5
@@ -37,7 +37,7 @@ jobs:
           context: https://github.com/tapis-project/event-engine.git#:pyevents
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/pyevents
+          tags: tapis/pyevents
       - name: Build and push pyevents:3.8
         uses: docker/build-push-action@v5
         with:
@@ -45,14 +45,14 @@ jobs:
           file: https://raw.githubusercontent.com/tapis-project/event-engine/main/pyevents/Dockerfile-3.8
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/pyevents:3.8
+          tags: tapis/pyevents:3.8
       - name: Build and push camera_traps_py
         uses: docker/build-push-action@v5
         with:
           context: src/python
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_py:${{ env.TRAPS_REL }}
+          tags: tapis/camera_traps_py:${{ env.TRAPS_REL }}
       - name: Build and push camera_traps_py_3.8
         uses: docker/build-push-action@v5
         with:
@@ -60,14 +60,14 @@ jobs:
           file: src/python/Dockerfile-3.8
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_py_3.8:${{ env.TRAPS_REL }}
+          tags: tapis/camera_traps_py_3.8:${{ env.TRAPS_REL }}
       - name: Build and push image_scoring_plugin
         uses: docker/build-push-action@v5
         with:
           context: external_plugins/image_scoring_plugin
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/image_scoring_plugin_py_3.8:${{ env.TRAPS_REL }}
+          tags: tapis/image_scoring_plugin_py_3.8:${{ env.TRAPS_REL }}
           build-args: REL=${{ env.TRAPS_REL }}
           file: external_plugins/image_scoring_plugin/Dockerfile-3.8
       - name: Build and push image_generating_plugin
@@ -76,7 +76,7 @@ jobs:
           context: external_plugins/image_generating_plugin
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/image_generating_plugin_py:${{ env.TRAPS_REL }}
+          tags: tapis/image_generating_plugin_py:${{ env.TRAPS_REL }}
           build-args: REL=${{ env.TRAPS_REL }}
       - name: Build and push power_measuring_plugin
         uses: docker/build-push-action@v5
@@ -84,5 +84,5 @@ jobs:
           context: external_plugins/power_measuring_plugin
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/power_measuring_plugin_py:${{ env.TRAPS_REL }}
+          tags: tapis/power_measuring_plugin_py:${{ env.TRAPS_REL }}
           build-args: REL=${{ env.TRAPS_REL }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,25 +23,49 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-#      - name: Build and push engine
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: .
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
-#          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
-#      - name: Build and push pyevents
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: https://github.com/tapis-project/event-engine.git#:pyevents
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          tags: skhuvis/pyevents
+      - name: Build and push engine
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
+          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+      - name: Build and push pyevents
+        uses: docker/build-push-action@v5
+        with:
+          context: https://github.com/tapis-project/event-engine.git#:pyevents
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/pyevents
       - name: Build and push camera_traps_py
         uses: docker/build-push-action@v5
         with:
           context: src/python
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_py
+          tags: skhuvis/camera_traps_py:${{ env.TRAPS_REL }}
+      - name: Build and push image_scoring_plugin
+        uses: docker/build-push-action@v5
+        with:
+          context: external_plugins/image_scoring_plugin
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/image_scoring_plugin_py:${{ env.TRAPS_REL }}
+          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+      - name: Build and push image_generating_plugin
+        uses: docker/build-push-action@v5
+        with:
+          context: external_plugins/image_generating_plugin
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/image_generating_plugin_py:${{ env.TRAPS_REL }}
+          build-args: TRAPS_REL=${{ env.TRAPS_REL }}
+      - name: Build and push power_measuring_plugin
+        uses: docker/build-push-action@v5
+        with:
+          context: external_plugins/power_measuring_plugin
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: skhuvis/power_measuring_plugin_py:${{ env.TRAPS_REL }}
+          build-args: TRAPS_REL=${{ env.TRAPS_REL }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,5 +29,5 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: skhuvis/camera_traps_engine:$TRAPS_REL
-          build-args: TRAPS_REL=$TRAPS_REL
+          tags: skhuvis/camera_traps_engine:${{ env.TRAPS_REL }}
+          build-args: TRAPS_REL=${{ env.TRAPS_REL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "camera-traps"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camera-traps"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # -------------------
 # First build phase: In this phase we do the build for release with an intermedidate layer that caches the dependencies
 # --------------------
-FROM rust:1.61 as builder
+FROM rust:1.68 as builder
 
 # install libzmq
 RUN USER=root apt-get update && apt-get install -y libzmq3-dev
@@ -19,6 +19,7 @@ WORKDIR /camera-traps
 # copy manifests
 COPY Cargo.lock ./Cargo.lock
 COPY Cargo.toml ./Cargo.toml
+COPY .cargo ./.cargo
 
 # build and cache only the dependencies
 RUN cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # -------------------
 # First build phase: In this phase we do the build for release with an intermedidate layer that caches the dependencies
 # --------------------
-FROM rust:1.68 as builder
+FROM rust:1.75 as builder
 
 # install libzmq
 RUN USER=root apt-get update && apt-get install -y libzmq3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cargo build --release
 # --------------------
 # Second build phase: Final base image. This is image will only include the minimum binary and configs
 # --------------------
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 # # still need to install zmq
 RUN USER=root apt-get update && apt-get install -y libzmq3-dev

--- a/external_plugins/image_generating_plugin/Dockerfile
+++ b/external_plugins/image_generating_plugin/Dockerfile
@@ -19,7 +19,7 @@
 #    docker run -v /path/to/input.json:/input.json -v /path/to/images:/input/path tapis/image_generating_plugin_py
 #
 ARG REL=use-build-arg
-FROM skhuvis/camera_traps_py:$REL
+FROM tapis/camera_traps_py:$REL
 
 RUN pip install opencv-contrib-python-headless 
 RUN pip install PILLOW

--- a/external_plugins/image_generating_plugin/Dockerfile
+++ b/external_plugins/image_generating_plugin/Dockerfile
@@ -19,7 +19,7 @@
 #    docker run -v /path/to/input.json:/input.json -v /path/to/images:/input/path tapis/image_generating_plugin_py
 #
 ARG REL=use-build-arg
-FROM tapis/camera_traps_py:$REL
+FROM skhuvis/camera_traps_py:$REL
 
 RUN pip install opencv-contrib-python-headless 
 RUN pip install PILLOW

--- a/external_plugins/image_scoring_plugin/Dockerfile
+++ b/external_plugins/image_scoring_plugin/Dockerfile
@@ -19,7 +19,7 @@
 #    docker run -v /path/to/input.json:/input.json -v /path/to/images:/input/path tapis/image_generating_plugin_py
 #
 ARG REL=use-build-arg
-FROM skhuvis/camera_traps_py:$REL
+FROM tapis/camera_traps_py:$REL
 
 RUN wget -O /md_v5a.0.0.pt https://github.com/microsoft/CameraTraps/releases/download/v5.0/md_v5a.0.0.pt
 

--- a/external_plugins/image_scoring_plugin/Dockerfile
+++ b/external_plugins/image_scoring_plugin/Dockerfile
@@ -19,7 +19,7 @@
 #    docker run -v /path/to/input.json:/input.json -v /path/to/images:/input/path tapis/image_generating_plugin_py
 #
 ARG REL=use-build-arg
-FROM tapis/camera_traps_py:$REL
+FROM skhuvis/camera_traps_py:$REL
 
 RUN wget -O /md_v5a.0.0.pt https://github.com/microsoft/CameraTraps/releases/download/v5.0/md_v5a.0.0.pt
 

--- a/external_plugins/image_scoring_plugin/Dockerfile-3.8
+++ b/external_plugins/image_scoring_plugin/Dockerfile-3.8
@@ -20,7 +20,7 @@
 # 3) For a specific image directory
 #    docker run -e IMAGE_PATH = /images
 ARG REL=use-build-arg
-FROM tapis/camera_traps_py_3.8:$REL
+FROM skhuvis/camera_traps_py_3.8:$REL
 
 RUN wget -O /md_v5a.0.0.pt https://github.com/microsoft/CameraTraps/releases/download/v5.0/md_v5a.0.0.pt
 

--- a/external_plugins/image_scoring_plugin/Dockerfile-3.8
+++ b/external_plugins/image_scoring_plugin/Dockerfile-3.8
@@ -20,7 +20,7 @@
 # 3) For a specific image directory
 #    docker run -e IMAGE_PATH = /images
 ARG REL=use-build-arg
-FROM skhuvis/camera_traps_py_3.8:$REL
+FROM tapis/camera_traps_py_3.8:$REL
 
 RUN wget -O /md_v5a.0.0.pt https://github.com/microsoft/CameraTraps/releases/download/v5.0/md_v5a.0.0.pt
 

--- a/external_plugins/power_measuring_plugin/Dockerfile
+++ b/external_plugins/power_measuring_plugin/Dockerfile
@@ -1,5 +1,5 @@
 ARG REL=use-build-arg
-FROM tapis/camera_traps_py_3.8:$REL
+FROM skhuvis/camera_traps_py:$REL
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN chmod +x $HOME/.cargo/env

--- a/external_plugins/power_measuring_plugin/Dockerfile
+++ b/external_plugins/power_measuring_plugin/Dockerfile
@@ -1,5 +1,5 @@
 ARG REL=use-build-arg
-FROM skhuvis/camera_traps_py:$REL
+FROM tapis/camera_traps_py:$REL
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN chmod +x $HOME/.cargo/env

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -1,5 +1,5 @@
 # Image: tapis/camera_traps_py
-FROM tapis/pyevents
+FROM skhuvis/pyevents
 
 ADD requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -1,5 +1,5 @@
 # Image: tapis/camera_traps_py
-FROM skhuvis/pyevents
+FROM tapis/pyevents
 
 ADD requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt


### PR DESCRIPTION
This request uses Github actions to push containers to Dockerhub. Container creation is triggered by a new release. The github action is defined in `.github/workflows/docker-image.yml`. Note that this required 2 changes to the main camera traps code:
1. Update rust version from 1.68 to 1.75
2. Update image from debian buster to bookwork.