### PR TITLE
Reorganize the image_scoring_plugin flake

### DIFF
--- a/external_plugins/image_scoring_plugin/flake.lock
+++ b/external_plugins/image_scoring_plugin/flake.lock
@@ -128,11 +128,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1680890900,
-        "narHash": "sha256-/puoLBgODn2k+YWUs3alUJQnWd9tm7map1iq5yQ1APY=",
+        "lastModified": 1696978057,
+        "narHash": "sha256-3zyFpE61W2FLalXXNSG2kbJnHqAr8yjfV3R2bdsfPbg=",
         "owner": "waltermoreira",
         "repo": "shell-utils",
-        "rev": "73186733b3a589bce196f03bc6290160a809b976",
+        "rev": "b421b6af9628dc5273ecff9a83d47d18f3004df9",
         "type": "github"
       },
       "original": {

--- a/external_plugins/image_scoring_plugin/flake.nix
+++ b/external_plugins/image_scoring_plugin/flake.nix
@@ -14,7 +14,7 @@
       let
         # see https://github.com/nix-community/poetry2nix/tree/master#api for more functions and examples.
         inherit (poetry2nix.legacyPackages.${system}) mkPoetryApplication mkPoetryEnv;
-        
+
         # Standard nix packages
         pkgs = nixpkgs.legacyPackages.${system};
         # Shell utilities used for creating the dev shell
@@ -31,50 +31,64 @@
         #
         # ai4eutils repo ----
         ai4eutils = myPython.pkgs.buildPythonPackage {
-            name = "ai4eutils";
-            src = pkgs.fetchgit {
-                url = "https://github.com/microsoft/ai4eutils";
-                rev = "a7aefc9cf6ff0564a83e0a1ddc903ef22561fdd5";
-                sha256 = "sha256-w1Eid+0exFzQobLjC3Eh1UlvLgauw/FY5H4LsnER3ek=";
-            };
-            format = "other";
-            installPhase = ''
-              mkdir -p $out/lib/python3.8/site-packages/ai4eutils
-              cp -r . $out/lib/python3.8/site-packages/ai4eutils/
-            '';
+          name = "ai4eutils";
+          src = pkgs.fetchgit {
+            url = "https://github.com/microsoft/ai4eutils";
+            rev = "a7aefc9cf6ff0564a83e0a1ddc903ef22561fdd5";
+            sha256 = "sha256-w1Eid+0exFzQobLjC3Eh1UlvLgauw/FY5H4LsnER3ek=";
+          };
+          format = "other";
+          installPhase = ''
+            mkdir -p $out/lib/python3.8/site-packages/ai4eutils
+            cp -r . $out/lib/python3.8/site-packages/ai4eutils/
+          '';
         };
 
         # cameratrapsMD repo ----
         cameraTrapsMD = myPython.pkgs.buildPythonPackage {
-            name = "camera_traps_MD"; 
-            src = pkgs.fetchFromGitHub {
-                owner = "sowbaranika1302";
-                repo = "camera_traps_MD";
-                rev = "28f91e01b2afadde23a0e653a4ab9d6879a976c9";
-                hash = "sha256-VBwprg1qvxtWBMOZpmJk6qqUhXUvmnVNqEvgoES4J5k=";
-            };
-            format = "other";
-            installPhase = ''
-              mkdir -p $out/lib/python3.8/site-packages/camera_traps_MD
-              cp -r . $out/lib/python3.8/site-packages/camera_traps_MD/
-            '';
+          name = "camera_traps_MD";
+          src = pkgs.fetchFromGitHub {
+            owner = "sowbaranika1302";
+            repo = "camera_traps_MD";
+            rev = "28f91e01b2afadde23a0e653a4ab9d6879a976c9";
+            hash = "sha256-VBwprg1qvxtWBMOZpmJk6qqUhXUvmnVNqEvgoES4J5k=";
+          };
+          format = "other";
+          installPhase = ''
+            mkdir -p $out/lib/python3.8/site-packages/camera_traps_MD
+            cp -r . $out/lib/python3.8/site-packages/camera_traps_MD/
+          '';
         };
 
         # yolov5 repo -----
         yolov5 = myPython.pkgs.buildPythonPackage {
-            name = "yolov5";
-            src = pkgs.fetchFromGitHub {
-                owner = "ultralytics";
-                repo = "yolov5";
-                rev = "c23a441c9df7ca9b1f275e8c8719c949269160d1";
-                hash = "sha256-YbedVzBResnU5lwlxYkMkjqJ0f1Q48FZs+tIS1a1MUk=";
-            };
-            format = "other";
-            installPhase = ''
-              mkdir -p $out/lib/python3.8/site-packages/yolov5
-              cp -r . $out/lib/python3.8/site-packages/yolov5/
-            '';
+          name = "yolov5";
+          src = pkgs.fetchFromGitHub {
+            owner = "ultralytics";
+            repo = "yolov5";
+            rev = "c23a441c9df7ca9b1f275e8c8719c949269160d1";
+            hash = "sha256-YbedVzBResnU5lwlxYkMkjqJ0f1Q48FZs+tIS1a1MUk=";
+          };
+          format = "other";
+          installPhase = ''
+            mkdir -p $out/lib/python3.8/site-packages/yolov5
+            cp -r . $out/lib/python3.8/site-packages/yolov5/
+          '';
         };
+
+        ctevents =
+          let mySrc = pkgs.fetchFromGitHub {
+            owner = "tapis-project";
+            repo = "camera-traps";
+            rev = "423ba3884d358b2716cd9a7da450d7a5df0f925a";
+            hash = "sha256-QaHQ2Bfuyz8+Qesp7bWZ1vEA7dIJUj60NqSub7QoKFo=";
+          };
+          in
+          mkPoetryApplication {
+            python = myPython;
+            projectDir = "${mySrc}/src/python";
+            preferWheels = true;
+          };
 
         # The score plugin also depends on a release of the Microsoft MegaDetector model.
         # Fetch the MegaDetector PyTorch model release (.pt) file
@@ -88,49 +102,78 @@
           src = self;
           dontBuild = true;
           installPhase = ''
-           mkdir -p $out;
-           cp ${mdPtModel} $out/md_v5a.0.0.pt
+            mkdir -p $out;
+            cp ${mdPtModel} $out/md_v5a.0.0.pt
           '';
         };
 
-        # Make a Python package with the Score Plugin source code and third-party dependencies 
-        # defined in the pyproject.toml file using the mkPoetryApplication function
-        myApp = mkPoetryApplication { 
-            python = myPython;
-            projectDir = ./.; 
-            preferWheels = true;
-          };
+        exampleImages = pkgs.stdenv.mkDerivation {
+          name = "example_images";
+          src = ./example_images;
+          installPhase = ''
+            mkdir -p $out
+            cp * $out
+          '';
+        };
 
-        # Bring everything together using a custom derivation. The approach is to wrap myApp
-        # with a shell script which calls the myApp binary (${myApp}/bin/image_scoring_plugin) after 
-        # doing the following:
-        #   1. changes to the directory containing the model.pt file.
-        #   2. sets the python path to include paths to the git repos installed above
-        # Note that 1) is needed because the score plugin code makes implicit assumption that
-        # pt model file is in the current working directory. 
-        myWrappedApp = pkgs.stdenv.mkDerivation {
-            name = "newMyApp";
-            buildInputs = [ myApp pkgs.makeWrapper ptModelDir ];
+        app = { kind, name }:
+          let
+            # Make a Python package with the Score Plugin source code and third-party dependencies 
+            # defined in the pyproject.toml file using the mkPoetryApplication function
+            # `kind` can be
+            # mkPoetryEnv: to build a Python interpreter with the right environment, or
+            # mkPoetryApplication: to build the actual executable
+            poetryApp = kind {
+              python = myPython;
+              projectDir = ./.;
+              preferWheels = true;
+            };
+          in
+          # Bring everything together using a custom derivation. The approach is to wrap myApp
+            # with a shell script which calls the myApp binary (${myApp}/bin/image_scoring_plugin) after 
+            # doing the following:
+            #   1. changes to the directory containing the model.pt file.
+            #   2. sets the python path to include paths to the git repos installed above
+            # Note that 1) is needed because the score plugin code makes implicit assumption that
+            # pt model file is in the current working directory. 
+          pkgs.stdenv.mkDerivation {
+            inherit name;
+            buildInputs = [ pkgs.makeWrapper ptModelDir ];
             src = self;
             dontBuild = true;
             installPhase = ''
-              makeWrapper ${myApp}/bin/image_scoring_plugin $out/bin/image_scoring_plugin \
+              makeWrapper ${poetryApp}/bin/${name} $out/bin/${name} \
               --chdir ${ptModelDir} \
+              --set IMAGES_DIR_PATH ${exampleImages} \
+              --set OUTPUT_DIR_PATH /tmp \
               --set PYTHONPATH \
-                "${cameraTrapsMD}/lib/python3.8/site-packages/camera_traps_MD:${cameraTrapsMD}/lib/python3.8/site-packages:${ai4eutils}/lib/python3.8/site-packages/ai4eutils:${yolov5}/lib/python3.8/site-packages/yolov5"
+              "${cameraTrapsMD}/lib/python3.8/site-packages:\
+              ${cameraTrapsMD}/lib/python3.8/site-packages/camera_traps_MD:\
+              ${ai4eutils}/lib/python3.8/site-packages/ai4eutils:\
+              ${yolov5}/lib/python3.8/site-packages/yolov5:\
+              ${ctevents}/lib/python3.8/site-packages"
             '';
+          };
+
+        # Put together the environment and the executable
+        fullApp = pkgs.symlinkJoin {
+          name = "image_scoring_plugin";
+          paths = [
+            (app
+              { kind = mkPoetryEnv; name = "python"; })
+            (app
+              { kind = mkPoetryApplication; name = "image_scoring_plugin"; })
+          ];
         };
       in
       rec {
         packages = {
-          app_package = myApp;
-          wrapped_app_package = myWrappedApp;
           # set the wrapped app package to the default package
-          default = packages.wrapped_app_package;
+          default = fullApp;
         };
 
         devShells.default = shell {
-          packages = [ poetry2nix.packages.${system}.poetry packages.wrapped_app_package ];
+          packages = [ poetry2nix.packages.${system}.poetry fullApp ];
         };
       });
 }


### PR DESCRIPTION
This PR improves the flake for `image_scoring_plugin`.

The main features are:
- Provides both the executable **and** a Python intepreter with the same environment as the executable, so it can be used for interactive experimentation.
- Successfully runs a basic test.

For executing the interactive environment, run
```
nix develop
python
```

For testing, run:
```
nix develop
python `realpath load_test_image_scoring.py`
```
(`realpath` is necessary because the interpreter has its $CWD pointing to the location of the model file, so it needs an explicit path to the Python file.)

Note that the flake can also build the code outside of the environment. For example, the following should work even outside of the development environment:
```
nix build
./result/bin/python `realpath load_test_image_scoring.py`
```
