### PR TITLE
Resolve Image Time Gap Issue in image_detecting_plugin

### DIFF
--- a/external_plugins/image_detecting_plugin/docker-compose.yml
+++ b/external_plugins/image_detecting_plugin/docker-compose.yml
@@ -30,5 +30,7 @@ services:
     privileged: true 
     volumes:
       - ./image_data:/var/lib/motion
+    environment:
+      - MIN_SECONDS_BETWEEN_IMAGES=2
     depends_on:
       - engine

--- a/external_plugins/image_detecting_plugin/image_detecting_plugin.py
+++ b/external_plugins/image_detecting_plugin/image_detecting_plugin.py
@@ -81,17 +81,24 @@ class NewFileHandler(FileSystemEventHandler):
     on_create.
     """
 
+    def __init__(self):
+        super().__init__()
+        self.last_image_time = 0
+
     def extract_timestamp(self, file_path):
         basename = os.path.basename(file_path)
         try:
-            # Expected format: 20250714-21:51:49-00.jpeg
+            # Expected format: 20250714-21:51:49-00.jpg
             if "-" in basename and ":" in basename:
-                # Splitting to get date and time parts
-                date_part, time_part = basename.split("-")[0], basename.split("-")[1]
-                datetime_str = date_part + time_part.replace(":", "")
-                if len(datetime_str) == 14:
-                    ts = time.strptime(datetime_str, "%Y%m%d%H%M%S")
-                    return time.mktime(ts)
+                # Splitting logic
+                parts = basename.split("-")
+                if len(parts) >= 2 and ":" in parts[1]:
+                    date_part = parts[0]
+                    time_part = parts[1].replace(":", "")
+                    datetime_str = date_part + time_part
+                    if len(datetime_str) == 14:
+                        ts = time.strptime(datetime_str, "%Y%m%d%H%M%S")
+                        return time.mktime(ts)
         except Exception as e:
             logging.warning(f"Filename parsing failed: {basename} — {e}")
 

--- a/external_plugins/image_detecting_plugin/image_detecting_plugin.py
+++ b/external_plugins/image_detecting_plugin/image_detecting_plugin.py
@@ -90,6 +90,7 @@ class NewFileHandler(FileSystemEventHandler):
         try:
             # Expected format: 20250714-21:51:49-00.jpg
             if "-" in basename and ":" in basename:
+                logging.info(f"TESTING 1 : {basename}")
                 # Splitting logic
                 parts = basename.split("-")
                 if len(parts) >= 2 and ":" in parts[1]:
@@ -125,6 +126,7 @@ class NewFileHandler(FileSystemEventHandler):
         """
         try:
             current_time = self.extract_timestamp(file_path)
+            logging.info(f"TESTING 2 : {current_time}")            
             if current_time - self.last_image_time < MIN_SECONDS_BETWEEN_IMAGES:
                 logging.info(f"Skipping image (too soon): {file_path}")
                 os.remove(file_path)

--- a/external_plugins/image_detecting_plugin/image_detecting_plugin.py
+++ b/external_plugins/image_detecting_plugin/image_detecting_plugin.py
@@ -16,7 +16,7 @@ from pyevents.events import get_plugin_socket
 # By default, we set this directory to `/var/lib/motion` in the container, assuming
 # that the Linux Motion package will also be configured and running in the same container.
 DATA_MONITORING_PATH = os.environ.get("DATA_MONITORING_PATH", "/var/lib/motion")
-
+MIN_SECONDS_BETWEEN_IMAGES = float(os.environ.get("MIN_SECONDS_BETWEEN_IMAGES", "5.0"))
 
 def get_socket():
     """
@@ -80,6 +80,28 @@ class NewFileHandler(FileSystemEventHandler):
     For now, we are only interested in *new* files, hence, we implement
     on_create.
     """
+
+    def extract_timestamp(self, file_path):
+        basename = os.path.basename(file_path)
+        try:
+            # Expected format: 20250714-21:51:49-00.jpeg
+            if "-" in basename and ":" in basename:
+                # Splitting to get date and time parts
+                date_part, time_part = basename.split("-")[0], basename.split("-")[1]
+                datetime_str = date_part + time_part.replace(":", "")
+                if len(datetime_str) == 14:
+                    ts = time.strptime(datetime_str, "%Y%m%d%H%M%S")
+                    return time.mktime(ts)
+        except Exception as e:
+            logging.warning(f"Filename parsing failed: {basename} — {e}")
+
+        # Fallback
+        try:
+            return os.path.getmtime(file_path)
+        except Exception as e:
+            logging.warning(f"Fallback to time.time(): {file_path} — {e}")
+            return time.time()
+        
     def on_closed(self, event):
         """
         Watch the directory for new files (not directories), and trigger the 
@@ -95,9 +117,17 @@ class NewFileHandler(FileSystemEventHandler):
         Basic processing of a new file event. 
         """
         try:
+            current_time = self.extract_timestamp(file_path)
+            if current_time - self.last_image_time < MIN_SECONDS_BETWEEN_IMAGES:
+                logging.info(f"Skipping image (too soon): {file_path}")
+                os.remove(file_path)
+                return
+
             logging.debug(f"Processing file at path: {file_path}")
             uuid = generate_new_image_event(file_path)
-            logging.info(f"Generated uuid ({uuid}) and successfully sent new image event for file: {file_path}")
+            if uuid:
+                self.last_image_time = current_time
+                logging.info(f"Generated uuid ({uuid}) and successfully sent new image event for file: {file_path}")
         except Exception as e:
             logging.error(f"Error processing {file_path}: {e}")
 

--- a/external_plugins/image_detecting_plugin/image_detecting_plugin.py
+++ b/external_plugins/image_detecting_plugin/image_detecting_plugin.py
@@ -16,7 +16,7 @@ from pyevents.events import get_plugin_socket
 # By default, we set this directory to `/var/lib/motion` in the container, assuming
 # that the Linux Motion package will also be configured and running in the same container.
 DATA_MONITORING_PATH = os.environ.get("DATA_MONITORING_PATH", "/var/lib/motion")
-MIN_SECONDS_BETWEEN_IMAGES = float(os.environ.get("MIN_SECONDS_BETWEEN_IMAGES", "5.0"))
+MIN_SECONDS_BETWEEN_IMAGES = float(os.environ.get("MIN_SECONDS_BETWEEN_IMAGES", "2.0"))
 
 def get_socket():
     """
@@ -90,7 +90,6 @@ class NewFileHandler(FileSystemEventHandler):
         try:
             # Expected format: 20250714-21:51:49-00.jpg
             if "-" in basename and ":" in basename:
-                logging.info(f"TESTING 1 : {basename}")
                 # Splitting logic
                 parts = basename.split("-")
                 if len(parts) >= 2 and ":" in parts[1]:
@@ -126,7 +125,6 @@ class NewFileHandler(FileSystemEventHandler):
         """
         try:
             current_time = self.extract_timestamp(file_path)
-            logging.info(f"TESTING 2 : {current_time}")            
             if current_time - self.last_image_time < MIN_SECONDS_BETWEEN_IMAGES:
                 logging.info(f"Skipping image (too soon): {file_path}")
                 os.remove(file_path)

--- a/installer/defaults.yml
+++ b/installer/defaults.yml
@@ -24,6 +24,7 @@ image_generating_log_level: DEBUG
 deploy_image_detecting: false
 image_detecting_plugin_image: tapis/image_detecting_plugin
 run_image_detecting_privileged: true
+min_seconds_between_images: 2
 motion_video_device: /dev/video0
 motion_framerate: 1
 motion_minimum_frame_time: 0

--- a/installer/defaults.yml
+++ b/installer/defaults.yml
@@ -26,9 +26,10 @@ image_detecting_plugin_image: tapis/image_detecting_plugin
 run_image_detecting_privileged: true
 motion_video_device: /dev/video0
 motion_framerate: 1
-motion_minimum_frame_time: 3
+motion_minimum_frame_time: 0
+motion_minimum_motion_frames: 1
 motion_event_gap: 1
-motion_threshold: 1500
+motion_threshold: 100
 motion_width: 640
 motion_height: 480
 

--- a/installer/templates/config/motion.conf
+++ b/installer/templates/config/motion.conf
@@ -84,7 +84,7 @@ threshold {{ motion_threshold }}
 despeckle_filter EedDl
 
 # Number of images that must contain motion to trigger an event.
-minimum_motion_frames 3
+minimum_motion_frames { motion_minimum_motion_frames }}
 
 # Gap in seconds of no motion detected that triggers the end of an event.
 event_gap {{ motion_event_gap }}

--- a/installer/templates/docker-compose.yml
+++ b/installer/templates/docker-compose.yml
@@ -106,6 +106,7 @@ services:
     pid: host
     environment:
       - IMAGE_DETECTING_PLUGIN_PORT=6002
+      - MIN_SECONDS_BETWEEN_IMAGES={{ min_seconds_between_images }}
     volumes:
       - {{ host_config_dir }}/motion.conf:/etc/motion/motion.conf:ro
     {% if run_image_detecting_privileged %}


### PR DESCRIPTION
This PR modifies the image_detecting_plugin to address the image time gap issue.

It compares the current image timestamp with the previous one and filters out images that do not meet the minimum time threshold.