### PR TITLE
Fix CKN power logging

### DIFF
--- a/external_plugins/ckn_plugin/ckn_plugin.py
+++ b/external_plugins/ckn_plugin/ckn_plugin.py
@@ -23,7 +23,79 @@ try:
     from power_processor import PowerProcessor
     POWER_PROCESSOR_AVAILABLE = True
 except ImportError:
-    POWER_PROCESSOR_AVAILABLE = False
+    # In many deployments, only this file is copied into the container (see Dockerfile),
+    # so a separate power_processor module is not available. Provide an internal fallback
+    # so power summary processing still works when ENABLE_POWER_MONITORING is enabled.
+    class PowerProcessor:
+        def __init__(
+            self,
+            summary_file,
+            kafka_producer,
+            kafka_topic,
+            experiment_id,
+            max_tries=5,
+            timeout=10,
+        ):
+            self.summary_file = summary_file
+            self.kafka_producer = kafka_producer
+            self.kafka_topic = kafka_topic
+            self.experiment_id = experiment_id
+            self.max_tries = int(max_tries) if max_tries is not None else 5
+            self.timeout = int(timeout) if timeout is not None else 10
+
+        def _wait_for_summary_file(self):
+            """
+            Wait for the power summary report file to exist and be readable.
+            The power monitoring plugin generates this near its shutdown, so the
+            CKN plugin may reach shutdown first.
+            """
+            last_err = None
+            for _ in range(max(self.max_tries, 1)):
+                try:
+                    if self.summary_file and os.path.exists(self.summary_file) and os.path.getsize(self.summary_file) > 0:
+                        return True
+                except Exception as e:
+                    last_err = e
+                time.sleep(max(self.timeout, 0))
+            if last_err:
+                raise last_err
+            return False
+
+        def process_summary_events(self):
+            """
+            Reads the summary JSON and publishes it to Kafka (if available).
+            Expected file is typically: /power_logs/power_summary_report.json
+            """
+            if not self.summary_file:
+                raise ValueError("summary_file is empty")
+
+            if not self._wait_for_summary_file():
+                raise FileNotFoundError(f"Power summary file not found or empty at {self.summary_file}")
+
+            with open(self.summary_file, "r") as f:
+                summary = json.load(f)
+
+            payload = {
+                "experiment_id": self.experiment_id,
+                "device_id": os.environ.get("CAMERA_TRAPS_DEVICE_ID", ""),
+                "user_id": os.environ.get("USER_ID", ""),
+                "power_summary_file": self.summary_file,
+                "power_summary": summary,
+            }
+
+            # If Kafka isn't available (or producer failed to initialize), we still
+            # consider "processing" successful once the file is readable.
+            if not self.kafka_producer:
+                logger.info("Kafka producer not initialized; read power summary successfully but will not publish to Kafka.")
+                logger.debug(f"Power summary payload: {json.dumps(payload)}")
+                return
+
+            # Publish summary to Kafka
+            value = json.dumps(payload)
+            self.kafka_producer.produce(self.kafka_topic, key=self.experiment_id, value=value)
+            self.kafka_producer.flush()
+
+    POWER_PROCESSOR_AVAILABLE = True
 
 log_level = os.environ.get("CKN_LOG_LEVEL", "INFO")
 logger = logging.getLogger("CKN Plugin")
@@ -166,12 +238,12 @@ def stream_event_to_kafka(event_data):
         
         # Add to processed set only if produce succeeds
         processed_uuids.add(uuid)
-        logger.info(f"Streamed event to Kafka for UUID: {uuid}")
+        logger.info(f"Streamed event to CKN broker for UUID: {uuid}")
         
     except BufferError as e:
-        logger.error(f"Buffer error streaming to Kafka: {e}")
+        logger.error(f"Buffer error streaming to CKN broker: {e}")
     except Exception as e:
-        logger.error(f"Kafka error streaming event: {e}")
+        logger.error(f"CKN broker error streaming event: {e}")
 
 
 def compute_total_images_generated():


### PR DESCRIPTION
This pull request introduces a fallback implementation for the `PowerProcessor` class directly within the `ckn_plugin.py` file to ensure power summary processing works even when the external `power_processor` module is unavailable. Additionally, it updates log messages to refer to the "CKN broker" instead of "Kafka" for improved clarity in event streaming logs.

**Power summary processing fallback:**

* Added an internal `PowerProcessor` class definition in `ckn_plugin.py` that handles reading the power summary file and optionally publishing its contents to Kafka, ensuring power monitoring remains functional even without the external module.

**Logging improvements:**

* Updated log messages in the `stream_event_to_kafka` function to refer to the "CKN broker" instead of "Kafka" for both successful event streaming and error cases, improving clarity and consistency in logs.